### PR TITLE
Clean up array to string conversion functions

### DIFF
--- a/src/core/font_renderer.js
+++ b/src/core/font_renderer.js
@@ -14,7 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* globals error, Stream, GlyphsUnicode, CFFParser, Encodings, Util */
+/* globals error, bytesToString, Stream, GlyphsUnicode, CFFParser, Encodings,
+           Util */
 
 'use strict';
 
@@ -675,7 +676,7 @@ var FontRendererFactory = (function FontRendererFactoryClosure() {
       var cmap, glyf, loca, cff, indexToLocFormat, unitsPerEm;
       var numTables = getUshort(data, 4);
       for (var i = 0, p = 12; i < numTables; i++, p += 16) {
-        var tag = String.fromCharCode.apply(null, data.subarray(p, p + 4));
+        var tag = bytesToString(data.subarray(p, p + 4));
         var offset = getLong(data, p + 8);
         var length = getLong(data, p + 12);
         switch (tag) {

--- a/src/core/fonts.js
+++ b/src/core/fonts.js
@@ -16,8 +16,8 @@
  */
 /* globals assert, bytesToString, CIDToUnicodeMaps, error, ExpertCharset,
            ExpertSubsetCharset, FileReaderSync, GlyphsUnicode,
-           info, isArray, isNum, ISOAdobeCharset, Stream,
-           stringToBytes, TextDecoder, warn, Lexer, Util,
+           info, isArray, isNum, ISOAdobeCharset, Stream, stringToArray,
+           stringToBytes, string32, TextDecoder, warn, Lexer, Util,
            FONT_IDENTITY_MATRIX, FontRendererFactory, shadow, isString,
            IdentityCMap, Name, CMapFactory, PDFJS */
 
@@ -372,7 +372,7 @@ var nonStdFontMap = {
   'MS-PMincho': 'MS PMincho',
   'MS-PMincho-Bold': 'MS PMincho-Bold',
   'MS-PMincho-BoldItalic': 'MS PMincho-BoldItalic',
-  'MS-PMincho-Italic': 'MS PMincho-Italic',
+  'MS-PMincho-Italic': 'MS PMincho-Italic'
 };
 
 var serifFonts = {
@@ -2328,22 +2328,6 @@ var Font = (function FontClosure() {
     this.loading = true;
   }
 
-  function stringToArray(str) {
-    var array = [];
-    for (var i = 0, ii = str.length; i < ii; ++i) {
-      array[i] = str.charCodeAt(i);
-    }
-    return array;
-  }
-
-  function arrayToString(arr) {
-    var strBuf = [];
-    for (var i = 0, ii = arr.length; i < ii; ++i) {
-      strBuf.push(String.fromCharCode(arr[i]));
-    }
-    return strBuf.join('');
-  }
-
   function int16(b0, b1) {
     return (b0 << 8) + b1;
   }
@@ -2368,22 +2352,13 @@ var Font = (function FontClosure() {
   }
 
   function string16(value) {
-    return (String.fromCharCode((value >> 8) & 0xff) +
-            String.fromCharCode(value & 0xff));
+    return String.fromCharCode((value >> 8) & 0xff, value & 0xff);
   }
 
   function safeString16(value) {
     // clamp value to the 16-bit int range
     value = (value > 0x7FFF ? 0x7FFF : (value < -0x8000 ? -0x8000 : value));
-    return (String.fromCharCode((value >> 8) & 0xff) +
-            String.fromCharCode(value & 0xff));
-  }
-
-  function string32(value) {
-    return (String.fromCharCode((value >> 24) & 0xff) +
-            String.fromCharCode((value >> 16) & 0xff) +
-            String.fromCharCode((value >> 8) & 0xff) +
-            String.fromCharCode(value & 0xff));
+    return String.fromCharCode((value >> 8) & 0xff, value & 0xff);
   }
 
   function createOpenTypeHeader(sfnt, file, numTables) {
@@ -2893,11 +2868,7 @@ var Font = (function FontClosure() {
 
     checkAndRepair: function Font_checkAndRepair(name, font, properties) {
       function readTableEntry(file) {
-        var tag = file.getBytes(4);
-        tag = String.fromCharCode(tag[0]) +
-              String.fromCharCode(tag[1]) +
-              String.fromCharCode(tag[2]) +
-              String.fromCharCode(tag[3]);
+        var tag = bytesToString(file.getBytes(4));
 
         var checksum = file.getUint32();
         var offset = file.getUint32();
@@ -2927,7 +2898,7 @@ var Font = (function FontClosure() {
 
       function readOpenTypeHeader(ttf) {
         return {
-          version: arrayToString(ttf.getBytes(4)),
+          version: bytesToString(ttf.getBytes(4)),
           numTables: ttf.getUint16(),
           searchRange: ttf.getUint16(),
           entrySelector: ttf.getUint16(),
@@ -4035,7 +4006,7 @@ var Font = (function FontClosure() {
       for (var i = 0; i < numTables; i++) {
         var table = tables[tablesNames[i]];
         var tableData = table.data;
-        ttf.file += arrayToString(tableData);
+        ttf.file += bytesToString(tableData);
 
         // 4-byte aligned data
         while (ttf.file.length & 3) {
@@ -4195,7 +4166,7 @@ var Font = (function FontClosure() {
       }
       for (var field in fields) {
         var table = fields[field];
-        otf.file += arrayToString(table);
+        otf.file += bytesToString(table);
       }
 
       return stringToArray(otf.file);
@@ -4293,7 +4264,7 @@ var Font = (function FontClosure() {
       // The viewer's choice, just use an identity map.
       var toUnicode = [];
       var firstChar = properties.firstChar, lastChar = properties.lastChar;
-      for (var i = firstChar, ii = lastChar; i <= ii; i++) {
+      for (var i = firstChar; i <= lastChar; i++) {
         toUnicode[i] = String.fromCharCode(i);
       }
       map.isIdentity = true;
@@ -5837,7 +5808,7 @@ var CFFParser = (function CFFParserClosure() {
           }
           data[j] = c;
         }
-        names.push(String.fromCharCode.apply(null, data));
+        names.push(bytesToString(data));
       }
       return names;
     },
@@ -5845,7 +5816,7 @@ var CFFParser = (function CFFParserClosure() {
       var strings = new CFFStrings();
       for (var i = 0, ii = index.count; i < ii; ++i) {
         var data = index.get(i);
-        strings.add(String.fromCharCode.apply(null, data));
+        strings.add(bytesToString(data));
       }
       return strings;
     },
@@ -6513,13 +6484,6 @@ var CFFOffsetTracker = (function CFFOffsetTrackerClosure() {
 
 // Takes a CFF and converts it to the binary representation.
 var CFFCompiler = (function CFFCompilerClosure() {
-  function stringToArray(str) {
-    var array = [];
-    for (var i = 0, ii = str.length; i < ii; ++i) {
-      array[i] = str.charCodeAt(i);
-    }
-    return array;
-  }
   function CFFCompiler(cff) {
     this.cff = cff;
   }

--- a/src/display/font_loader.js
+++ b/src/display/font_loader.js
@@ -14,7 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* globals PDFJS, shadow, isWorker, assert, warn, bytesToString, globalScope */
+/* globals PDFJS, shadow, isWorker, assert, warn, bytesToString, string32, 
+           globalScope */
 
 'use strict';
 
@@ -161,13 +162,6 @@ var FontLoader = {
                (data.charCodeAt(offset + 1) << 16) |
                (data.charCodeAt(offset + 2) << 8) |
                (data.charCodeAt(offset + 3) & 0xff);
-      }
-
-      function string32(value) {
-        return String.fromCharCode((value >> 24) & 0xff) +
-               String.fromCharCode((value >> 16) & 0xff) +
-               String.fromCharCode((value >> 8) & 0xff) +
-               String.fromCharCode(value & 0xff);
       }
 
       function spliceString(s, offset, remove, insert) {

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -152,7 +152,7 @@ var OPS = PDFJS.OPS = {
   paintInlineImageXObjectGroup: 87,
   paintImageXObjectRepeat: 88,
   paintImageMaskXObjectRepeat: 89,
-  paintSolidColorImageMask: 90,
+  paintSolidColorImageMask: 90
 };
 
 // A notice for devs. These are good for things that are helpful to devs, such
@@ -393,21 +393,39 @@ var XRefParseException = (function XRefParseExceptionClosure() {
 
 
 function bytesToString(bytes) {
-  var strBuf = [];
   var length = bytes.length;
-  for (var n = 0; n < length; ++n) {
-    strBuf.push(String.fromCharCode(bytes[n]));
+  var MAX_ARGUMENT_COUNT = 65000;
+  if (length < MAX_ARGUMENT_COUNT) {
+    return String.fromCharCode.apply(null, bytes);
+  }
+  var strBuf = [];
+  for (var i = 0; i < length; ++i) {
+    strBuf.push(String.fromCharCode(bytes[i]));
   }
   return strBuf.join('');
+}
+
+function stringToArray(str) {
+  var length = str.length;
+  var array = [];
+  for (var i = 0; i < length; ++i) {
+    array[i] = str.charCodeAt(i);
+  }
+  return array;
 }
 
 function stringToBytes(str) {
   var length = str.length;
   var bytes = new Uint8Array(length);
-  for (var n = 0; n < length; ++n) {
-    bytes[n] = str.charCodeAt(n) & 0xFF;
+  for (var i = 0; i < length; ++i) {
+    bytes[i] = str.charCodeAt(i) & 0xFF;
   }
   return bytes;
+}
+
+function string32(value) {
+  return String.fromCharCode((value >> 24) & 0xff, (value >> 16) & 0xff,
+                             (value >> 8) & 0xff, value & 0xff);
 }
 
 var IDENTITY_MATRIX = [1, 0, 0, 1, 0, 0];


### PR DESCRIPTION
This PR does the following:
1. Move `fonts.js->Font.string32` and `fonts_loader.js->FontLoader.string32` to `Utils.js->string32`
2. Move `fonts.js->Font.stringToArray` and `fonts.js->CFFCompiler.stringToArray` to `Utils.js->stringToArray`
3. remove `fonts.js->Font.arrayToString` and use `Utils.js->bytesToString` instead
4. Use `String.fromCharCode(a, b)` instead of `String.fromCharCode(a) + String.fromCharCode(b)`
5. In `Utils.js->bytesToString`, use `String.fromCharCode.apply(null, bytes)` instead of pushing chars to an array when "possible" (because its >10x faster for longer arrays).
   If the bytes array is too long, a "too many arguments" warning will appear. **Question**: What is the maximum number of function arguments that is accepted by all browsers? FF/chrome/ie7 accept 500000/120000/120000 arguments, so I felt that a maximum of 65000 should be safe.
